### PR TITLE
Move react-scripts to devDepdencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
     "prettier": "^2.7.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1",
     "spotify-web-api-node": "^5.0.2",
     "web-vitals": "^2.1.0"
+  },
+  "devDependencies": {
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Dependabot pops lots of warnings for the build tool that are irrelevant, and not true vulerabilities in the webapp. 

This attempts to silence those by moving `react-scripts` to `devDependencies`